### PR TITLE
Adding the footnotes Markdown extension

### DIFF
--- a/mark2epub.py
+++ b/mark2epub.py
@@ -32,7 +32,7 @@ def get_all_filenames(the_dir,extensions=[]):
 
 
 def get_packageOPF_XML(md_filenames=[],image_filenames=[],css_filenames=[],description_data=None):
-    
+
     doc = minidom.Document()
 
     package = doc.createElement('package')
@@ -40,12 +40,12 @@ def get_packageOPF_XML(md_filenames=[],image_filenames=[],css_filenames=[],descr
     package.setAttribute('version',"3.0")
     package.setAttribute('xml:lang',"en")
     package.setAttribute("unique-identifier","pub-id")
-    
+
     ## Now building the metadata
 
     metadata = doc.createElement('metadata')
     metadata.setAttribute('xmlns:dc', 'http://purl.org/dc/elements/1.1/')
-    
+
     for k,v in description_data["metadata"].items():
         if len(v):
             x = doc.createElement(k)
@@ -54,12 +54,12 @@ def get_packageOPF_XML(md_filenames=[],image_filenames=[],css_filenames=[],descr
                     x.setAttribute('id',id_label)
             x.appendChild(doc.createTextNode(v))
             metadata.appendChild(x)
-    
+
 
     ## Now building the manifest
 
     manifest = doc.createElement('manifest')
-    
+
     ## TOC.xhtml file for EPUB 3
     x = doc.createElement('item')
     x.setAttribute('id',"toc")
@@ -67,27 +67,27 @@ def get_packageOPF_XML(md_filenames=[],image_filenames=[],css_filenames=[],descr
     x.setAttribute('href',"TOC.xhtml")
     x.setAttribute('media-type',"application/xhtml+xml")
     manifest.appendChild(x)
-    
+
     ## Ensure retrocompatibility by also providing a TOC.ncx file
     x = doc.createElement('item')
     x.setAttribute('id',"ncx")
     x.setAttribute('href',"toc.ncx")
     x.setAttribute('media-type',"application/x-dtbncx+xml")
     manifest.appendChild(x)
-    
+
     x = doc.createElement('item')
     x.setAttribute('id',"titlepage")
     x.setAttribute('href',"titlepage.xhtml")
     x.setAttribute('media-type',"application/xhtml+xml")
     manifest.appendChild(x)
-    
+
     for i,md_filename in enumerate(md_filenames):
         x = doc.createElement('item')
         x.setAttribute('id',"s{:05d}".format(i))
         x.setAttribute('href',"s{:05d}-{}.xhtml".format(i,md_filename.split(".")[0]))
         x.setAttribute('media-type',"application/xhtml+xml")
         manifest.appendChild(x)
-        
+
     for i,image_filename in enumerate(image_filenames):
         x = doc.createElement('item')
         x.setAttribute('id',"image-{:05d}".format(i))
@@ -102,26 +102,26 @@ def get_packageOPF_XML(md_filenames=[],image_filenames=[],css_filenames=[],descr
             x.setAttribute('media-type',"image/png")
         if image_filename==description_data["cover_image"]:
             x.setAttribute('properties',"cover-image")
-            
+
             ## Ensure compatibility by also providing a meta tag in the metadata
             y = doc.createElement('meta')
             y.setAttribute('name',"cover")
             y.setAttribute('content',"image-{:05d}".format(i))
             metadata.appendChild(y)
         manifest.appendChild(x)
-        
+
     for i,css_filename in enumerate(css_filenames):
         x = doc.createElement('item')
         x.setAttribute('id',"css-{:05d}".format(i))
         x.setAttribute('href',"css/{}".format(css_filename))
         x.setAttribute('media-type',"text/css")
         manifest.appendChild(x)
-        
+
     ## Now building the spine
-    
+
     spine = doc.createElement('spine')
     spine.setAttribute('toc', "ncx")
-    
+
     x = doc.createElement('itemref')
     x.setAttribute('idref',"titlepage")
     x.setAttribute('linear',"yes")
@@ -131,7 +131,7 @@ def get_packageOPF_XML(md_filenames=[],image_filenames=[],css_filenames=[],descr
         x.setAttribute('idref',"s{:05d}".format(i))
         x.setAttribute('linear',"yes")
         spine.appendChild(x)
-        
+
     guide = doc.createElement('guide')
     x = doc.createElement('reference')
     x.setAttribute('type',"cover")
@@ -147,7 +147,7 @@ def get_packageOPF_XML(md_filenames=[],image_filenames=[],css_filenames=[],descr
     doc.appendChild(package)
 
     return doc.toprettyxml()
- 
+
 
 def get_container_XML():
     container_data = """<?xml version="1.0" encoding="UTF-8" ?>\n"""
@@ -155,7 +155,7 @@ def get_container_XML():
     container_data += """<rootfiles>\n"""
     container_data += """<rootfile full-path="OPS/package.opf" media-type="application/oebps-package+xml"/>\n"""
     container_data += """</rootfiles>\n</container>"""
-    
+
     return container_data
 
 
@@ -167,9 +167,9 @@ def get_coverpage_XML(cover_image_path):
     all_xhtml += """<head>\n</head>\n<body>\n"""
     all_xhtml += """<img src="images/{}" style="height:100%;max-width:100%;"/>\n""".format(cover_image_path)
     all_xhtml += """</body>\n</html>"""
-    
+
     return all_xhtml
-    
+
 def get_TOC_XML(default_css_filenames,markdown_filenames):
     ## Returns the XML data for the TOC.xhtml file
 
@@ -186,12 +186,12 @@ def get_TOC_XML(default_css_filenames,markdown_filenames):
     for i,md_filename in enumerate(markdown_filenames):
         toc_xhtml += """<li><a href="s{:05d}-{}.xhtml">{}</a></li>""".format(i,md_filename.split(".")[0],md_filename.split(".")[0])
     toc_xhtml += """</ol>\n</nav>\n</body>\n</html>"""
-    
+
     return toc_xhtml
-    
+
 def get_TOCNCX_XML(markdown_filenames):
     ## Returns the XML data for the TOC.ncx file
-    
+
     toc_ncx = """<?xml version="1.0" encoding="UTF-8"?>\n"""
     toc_ncx += """<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" xml:lang="fr" version="2005-1">\n"""
     toc_ncx += """<head>\n</head>\n"""
@@ -202,39 +202,39 @@ def get_TOCNCX_XML(markdown_filenames):
         toc_ncx += """<content src="s{:05d}-{}.xhtml"/>""".format(i,md_filename.split(".")[0])
         toc_ncx += """ </navPoint>"""
     toc_ncx += """</navMap>\n</ncx>"""
-    
+
     return toc_ncx
-    
+
 def get_chapter_XML(md_filename,css_filenames):
     ## Returns the XML data for a given markdown chapter file, with the corresponding css chapter files
 
     with open(os.path.join(work_dir,md_filename),"r",encoding="utf-8") as f:
         markdown_data = f.read()
     html_text = markdown.markdown(markdown_data,
-                                  extensions=["codehilite","tables","fenced_code"],
+                                  extensions=["codehilite","tables","fenced_code","footnotes"],
                                   extension_configs={"codehilite":{"guess_lang":False}}
-                                  ) 
+                                  )
 
     all_xhtml = """<?xml version="1.0" encoding="UTF-8"?>\n"""
     all_xhtml += """<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="en">\n"""
     all_xhtml += """<head>\n<meta http-equiv="default-style" content="text/html; charset=utf-8"/>\n"""
 
-    
+
     for css_filename in css_filenames:
         all_xhtml += """<link rel="stylesheet" href="css/{}" type="text/css"/>\n""".format(css_filename)
-    
+
     all_xhtml += """</head>\n<body>\n"""
 
     all_xhtml += html_text
     all_xhtml += """\n</body>\n</html>"""
-    
+
     return all_xhtml
 
 if __name__ == "__main__":
     if len(sys.argv[1:])<2:
         print("\nUsage:\n    python md2epub.py <markdown_directory> <output_file.epub>")
         exit(1)
-     
+
 
     work_dir = sys.argv[1]
     output_path = sys.argv[2]
@@ -247,7 +247,7 @@ if __name__ == "__main__":
 
     with open(os.path.join(work_dir,"description.json"),"r") as f:
         json_data = json.load(f)
-        
+
     all_md_filenames=[]
     all_css_filenames=json_data["default_css"][:]
     for chapter in json_data["chapters"]:
@@ -256,10 +256,10 @@ if __name__ == "__main__":
         if len(chapter["css"]) and (not chapter["css"] in all_css_filenames):
             all_css_filenames.append(chapter["css"])
     all_image_filenames = get_all_filenames(images_dir,extensions=["gif","jpg","jpeg","png"])
- 
+
     ######################################################
     ## Now creating the ePUB book
- 
+
     with zipfile.ZipFile(output_path, "w" ) as myZipFile:
 
         ## First, write the mimetype
@@ -276,7 +276,7 @@ if __name__ == "__main__":
                                           description_data=json_data
                                          )
         myZipFile.writestr("OPS/package.opf",package_data, zipfile.ZIP_DEFLATED)
-        
+
         ## First, we create the cover page
         coverpage_data = get_coverpage_XML(json_data["cover_image"])
         myZipFile.writestr("OPS/titlepage.xhtml",coverpage_data.encode('utf-8'),zipfile.ZIP_DEFLATED)
@@ -287,21 +287,21 @@ if __name__ == "__main__":
             chapter_css_filenames = json_data["default_css"][:]
             if len(chapter["css"]):
                 chapter_css_filenames.append(chapter["css"])
-                
+
             chapter_data = get_chapter_XML(chapter_md_filename,chapter_css_filenames)
             myZipFile.writestr("OPS/s{:05d}-{}.xhtml".format(i,chapter_md_filename.split(".")[0]),
                                chapter_data.encode('utf-8'),
                                zipfile.ZIP_DEFLATED)
-            
-        
+
+
         ## Writing the TOC.xhtml file
         toc_xml_data = get_TOC_XML(json_data["default_css"],all_md_filenames)
         myZipFile.writestr("OPS/TOC.xhtml",toc_xml_data.encode('utf-8'),zipfile.ZIP_DEFLATED)
-        
+
         ## Writing the TOC.ncx file
-        toc_ncx_data = get_TOCNCX_XML(all_md_filenames)       
+        toc_ncx_data = get_TOCNCX_XML(all_md_filenames)
         myZipFile.writestr("OPS/toc.ncx",toc_ncx_data.encode('utf-8'),zipfile.ZIP_DEFLATED)
-        
+
         ## Copy image files
         for i,image_filename in enumerate(all_image_filenames):
             with open(os.path.join(images_dir,image_filename),"rb") as f:


### PR DESCRIPTION
First of all: Thank you for a great little tool!


This PR adds the [footnotes Markdown extension](https://python-markdown.github.io/extensions/). This allows documents with footnotes to be correctly handled.

My editor also formatted away trailing white-space; sorry for the extra noise.